### PR TITLE
Initialize AOI inspector skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Semiconductor AOI Inspector
+
+기본적인 CLI 기반 반도체 자동 광학 검사(AOI) 도구의 골격입니다. `AOI_Inspector_SDD.md` 문서에서 정의된 모듈 구조를 참고하여 구성되었습니다.
+
+## 구조
+- `main.py`: 프로그램 진입점
+- `modules/`: 데이터 로딩, 전처리, 추론, 후처리, 시각화 모듈
+- `models/`: 사전 학습된 모델 파일 보관 위치
+- `config.yaml`: 실행 설정 파일
+
+## 실행 방법
+```
+python main.py --config config.yaml
+```
+
+현재는 예제 수준의 코드로, 실제 모델과 데이터는 별도 준비가 필요합니다.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,2 @@
+data_folder: images
+model_path: models/yolov5s.pt

--- a/main.py
+++ b/main.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import yaml
+
+from modules.data_loader import load_images_from_folder
+from modules.preprocessor import preprocess_image
+from modules.inference import load_model, run_inference
+from modules.postprocessor import summarize_detection
+from modules.visualizer import save_result_image
+
+
+def main(config_path: str = "config.yaml") -> None:
+    config = yaml.safe_load(Path(config_path).read_text())
+    data_folder = config.get("data_folder", "images")
+    model_path = config.get("model_path", "models/yolov5s.pt")
+
+    images = load_images_from_folder(data_folder)
+    if not images:
+        print("이미지를 찾을 수 없습니다.")
+        return
+
+    model = load_model(model_path)
+
+    for idx, img in enumerate(images):
+        processed = preprocess_image(img)
+        results = run_inference(processed)
+        summary = summarize_detection(results)
+        print(f"[Image {idx}] {summary}")
+        save_result_image(img, results, f"output_{idx}.jpg")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/data_loader.py
+++ b/modules/data_loader.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import List
+
+import cv2
+import numpy as np
+
+def load_images_from_folder(folder_path: str) -> List[np.ndarray]:
+    """폴더 내의 이미지 파일을 모두 읽어 리스트로 반환합니다."""
+    images = []
+    folder = Path(folder_path)
+    for ext in ("*.png", "*.jpg", "*.jpeg", "*.bmp"):
+        for img_path in folder.glob(ext):
+            img = cv2.imread(str(img_path))
+            if img is not None:
+                images.append(img)
+    return images

--- a/modules/inference.py
+++ b/modules/inference.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+import torch
+import numpy as np
+
+_model: Any = None
+
+def load_model(model_path: str) -> Any:
+    """모델을 로드하고 evaluation 모드로 설정합니다."""
+    global _model
+    _model = torch.load(model_path, map_location="cpu")
+    _model.eval()
+    return _model
+
+def run_inference(img: np.ndarray):
+    """단순 예시용 추론 함수."""
+    if _model is None:
+        raise RuntimeError("모델이 로드되지 않았습니다.")
+    with torch.no_grad():
+        tensor = torch.from_numpy(img).unsqueeze(0).float()
+        return _model(tensor)

--- a/modules/postprocessor.py
+++ b/modules/postprocessor.py
@@ -1,0 +1,6 @@
+from typing import Iterable
+
+def summarize_detection(results: Iterable) -> str:
+    """결과 객체의 개수를 요약한 문자열을 반환합니다."""
+    count = len(results) if results is not None else 0
+    return f"감지된 객체 수: {count}"

--- a/modules/preprocessor.py
+++ b/modules/preprocessor.py
@@ -1,0 +1,8 @@
+import cv2
+import numpy as np
+
+def preprocess_image(img: np.ndarray) -> np.ndarray:
+    """이미지를 흑백으로 변환 후 히스토그램 평활화를 수행합니다."""
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    normalized = cv2.equalizeHist(gray)
+    return normalized

--- a/modules/visualizer.py
+++ b/modules/visualizer.py
@@ -1,0 +1,15 @@
+from typing import List
+
+import cv2
+import numpy as np
+
+
+def save_result_image(img: np.ndarray, detections: List, path: str) -> None:
+    """감지된 영역을 사각형으로 표시하여 저장합니다."""
+    output = img.copy()
+    for det in detections:
+        bbox = det.get("bbox") if isinstance(det, dict) else None
+        if bbox is not None and len(bbox) == 4:
+            x1, y1, x2, y2 = bbox
+            cv2.rectangle(output, (x1, y1), (x2, y2), (0, 255, 0), 2)
+    cv2.imwrite(path, output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python
+numpy
+PyYAML
+torch


### PR DESCRIPTION
## Summary
- add module skeletons `data_loader`, `preprocessor`, `inference`, `postprocessor`, and `visualizer`
- add `main.py` entry point
- include default `config.yaml`, `requirements.txt`, and placeholder model folder
- document usage in `README`

## Testing
- `python -m py_compile main.py modules/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6844c060e1a48321b44ad52583acb0d2