### PR TITLE
Fix additional data loader tests and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ pip install -r requirements.txt
 ```bash
 pip install -r requirements.txt
 ```
+
+## 테스트 실행
+
+의존성 설치 후 루트 디렉터리에서 다음 명령어로 테스트를 실행합니다.
+
+```bash
+pytest -q
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ ultralytics
 anomalib
 albumentations
 PyYAML
+pytest

--- a/tests/test_data_loader_additional.py
+++ b/tests/test_data_loader_additional.py
@@ -1,0 +1,34 @@
+import os
+from pathlib import Path
+import unittest
+import numpy as np
+import cv2
+
+from modules.data_loader import load_images_from_folder
+
+class TestDataLoaderAdditional(unittest.TestCase):
+    def test_returns_empty_and_prints_warning_when_no_images(self):
+        with unittest.mock.patch("builtins.print") as mock_print:
+            from tempfile import TemporaryDirectory
+            with TemporaryDirectory() as tmpdir:
+                Path(os.path.join(tmpdir, "a.txt")).write_text("not image")
+                images = load_images_from_folder(tmpdir)
+                self.assertEqual(images, [])
+                mock_print.assert_any_call("경고: 유효한 이미지가 없습니다.")
+
+    def test_skip_unreadable_image(self):
+        with unittest.mock.patch("cv2.imread", return_value=None) as mock_read, \
+             unittest.mock.patch("builtins.print") as mock_print:
+            from tempfile import TemporaryDirectory
+            with TemporaryDirectory() as tmpdir:
+                Path(os.path.join(tmpdir, "img.png")).write_bytes(b"fake")
+                images = load_images_from_folder(tmpdir)
+                self.assertEqual(images, [])
+                self.assertTrue(mock_read.called)
+                mock_print.assert_any_call(
+                    f"경고: 이미지를 불러오지 못했습니다: {Path(tmpdir) / 'img.png'}"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add pytest to requirements
- complete missing portions of `test_data_loader_additional.py`
- document how to run tests in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844d9f813848321ac710af37c44f06c