### PR TITLE
Fix missing modules package

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the LiteAOI project."""


### PR DESCRIPTION
## Summary
- add `__init__.py` to make `modules` a package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844dd3bc5288321bac4827368fd2f17