### PR TITLE
Add LiteAOI skeleton and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# LiteAOI
+
+LiteAOI는 단순한 자동 시각 검사 예제 프로젝트입니다. 본 리포지토리는 4+1 뷰로 설계된 아키텍처 문서를 기반으로 기본적인 코드 구조만을 제공합니다.
+
+## 환경 준비
+
+- Python 3.10 이상
+- PyTorch
+- OpenCV
+- Albumentations
+- Anomalib
+
+필요한 패키지는 `requirements.txt`를 참고하여 설치합니다.
+
+```bash
+pip install -r requirements.txt
+```
+
+## 사용 방법
+
+### 학습
+
+학습 데이터를 이용하여 모델을 학습하고 싶다면 다음과 같이 실행합니다.
+
+```bash
+python train.py --dataset ./datasets/wafer --output ./models/mymodel_v1.pt
+```
+
+### 추론
+
+학습된 모델을 사용하여 이미지를 분석하려면 다음 명령을 사용합니다.
+
+```bash
+python infer.py --input ./test_images --model ./models/mymodel_v1.pt
+```
+
+## 폴더 구조
+
+문서의 Development View에서 제시된 구조를 따릅니다.
+
+```text
+project_root/
+├── train.py
+├── infer.py
+├── modules/
+│   ├── trainer.py
+│   ├── model_loader.py
+│   ├── model_downloader.py
+│   ├── data_loader.py
+│   ├── preprocessor.py
+│   ├── inference.py
+│   ├── postprocessor.py
+│   └── visualizer.py
+├── models/
+├── datasets/
+├── config.yaml
+└── README.md
+```

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+dataset: ./datasets/wafer
+output_model: ./models/mymodel_v1.pt
+batch_size: 4
+epochs: 1

--- a/infer.py
+++ b/infer.py
@@ -1,0 +1,32 @@
+"""추론 진입점."""
+import argparse
+import yaml
+from modules.model_loader import load_model
+from modules.data_loader import load_images
+from modules.preprocessor import preprocess
+from modules.inference import run_inference
+from modules.postprocessor import summarize
+from modules.visualizer import visualize
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="LiteAOI 추론 스크립트")
+    parser.add_argument("--input", type=str, help="입력 이미지 디렉터리")
+    parser.add_argument("--model", type=str, help="모델 파일 경로")
+    parser.add_argument("--config", default="config.yaml", help="설정 파일 경로")
+    parser.add_argument("--save", default="./results", help="결과 저장 폴더")
+    args = parser.parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    model = load_model(args.model)
+    images = load_images(args.input)
+    processed = preprocess(images)
+    results = run_inference(model, processed)
+    summarized = summarize(results)
+    visualize(summarized, args.save)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,1 @@
+# LiteAOI modules

--- a/modules/data_loader.py
+++ b/modules/data_loader.py
@@ -1,0 +1,8 @@
+"""데이터 로딩을 담당하는 모듈."""
+from typing import List
+
+
+def load_images(path: str) -> List[str]:
+    """지정된 경로에서 이미지 파일 목록을 가져옵니다."""
+    print(f"이미지 로드: {path}")
+    return []

--- a/modules/inference.py
+++ b/modules/inference.py
@@ -1,0 +1,8 @@
+"""추론을 실행하는 모듈."""
+from typing import Any, List
+
+
+def run_inference(model: Any, images: List[str]) -> List[Any]:
+    """모델과 전처리된 이미지로 추론을 수행합니다."""
+    print("추론 실행 ...")
+    return []

--- a/modules/model_downloader.py
+++ b/modules/model_downloader.py
@@ -1,0 +1,7 @@
+"""사전 학습 모델을 다운로드하는 모듈."""
+
+
+def download_pretrained(model_name: str, save_path: str) -> None:
+    """모델을 다운로드하여 지정된 경로에 저장합니다."""
+    print(f"{model_name} 모델 다운로드... -> {save_path}")
+    # 실제 다운로드 로직은 생략

--- a/modules/model_loader.py
+++ b/modules/model_loader.py
@@ -1,0 +1,9 @@
+"""학습된 모델을 로드하는 모듈."""
+from typing import Any
+
+
+def load_model(model_path: str) -> Any:
+    """모델 파일을 읽어 로드합니다."""
+    print(f"모델 로드: {model_path}")
+    # 실제 로딩 로직은 생략
+    return None

--- a/modules/postprocessor.py
+++ b/modules/postprocessor.py
@@ -1,0 +1,8 @@
+"""추론 결과를 정리하는 모듈."""
+from typing import Any, List
+
+
+def summarize(results: List[Any]) -> List[Any]:
+    """추론 결과를 요약합니다."""
+    print("결과 요약 ...")
+    return results

--- a/modules/preprocessor.py
+++ b/modules/preprocessor.py
@@ -1,0 +1,8 @@
+"""이미지 전처리 모듈."""
+from typing import List
+
+
+def preprocess(images: List[str]) -> List[str]:
+    """이미지를 전처리합니다."""
+    print("전처리 중 ...")
+    return images

--- a/modules/trainer.py
+++ b/modules/trainer.py
@@ -1,0 +1,17 @@
+"""모델 학습을 담당하는 모듈."""
+from typing import Any, Dict
+
+
+def train_model(config: Dict[str, Any]) -> None:
+    """주어진 설정으로 모델을 학습하고 저장합니다.
+
+    Args:
+        config: 학습에 필요한 설정 딕셔너리. ``output_model`` 경로가 포함되어야 합니다.
+    """
+    dataset_path = config.get("dataset")
+    output_model = config.get("output_model")
+
+    # 실제 학습 로직은 생략되어 있습니다.
+    print(f"데이터셋 로드: {dataset_path}")
+    print("모델 학습 중 ...")
+    print(f"학습된 모델 저장: {output_model}")

--- a/modules/visualizer.py
+++ b/modules/visualizer.py
@@ -1,0 +1,7 @@
+"""결과 시각화 모듈."""
+from typing import Any, List
+
+
+def visualize(results: List[Any], save_dir: str) -> None:
+    """결과를 시각화하여 저장합니다."""
+    print(f"시각화 저장: {save_dir}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# 기본 의존성 목록
+PyYAML
+opencv-python
+albumentations
+# 실제 프로젝트에서는 PyTorch와 Anomalib 버전에 맞춰 수정

--- a/train.py
+++ b/train.py
@@ -1,0 +1,24 @@
+"""학습 진입점."""
+import argparse
+import yaml
+from modules.trainer import train_model
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="LiteAOI 학습 스크립트")
+    parser.add_argument("--dataset", type=str, help="데이터셋 경로")
+    parser.add_argument("--output", type=str, help="모델 저장 경로")
+    parser.add_argument("--config", default="config.yaml", help="설정 파일 경로")
+    args = parser.parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    config["dataset"] = args.dataset
+    config["output_model"] = args.output
+
+    train_model(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add LiteAOI sample implementation based on architecture docs
- implement trainer, loader, preprocessing modules
- provide train/infer entrypoints
- document setup and usage in README

## Testing
- `python -m py_compile $(find . -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_684e218e2d40832193df0ed7c0717627