### PR TITLE
Add pretrained model loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ pip install -r requirements.txt
 
 ### 학습
 
-학습 데이터를 이용하여 모델을 학습하고 싶다면 다음과 같이 실행합니다.
+학습 스크립트는 개발자용으로 제공되며, 프로젝트 폴더에 위치한 사전 학습 모델을
+불러올 수 있습니다. 다음과 같이 실행합니다.
 
 ```bash
-python train.py --dataset ./datasets/wafer --output ./models/mymodel_v1.pt
+python train.py --dataset ./datasets/wafer --output ./models/mymodel_v1.pt \
+    --pretrained ./models/pretrained.pt
 ```
 
 ### 추론

--- a/config.yaml
+++ b/config.yaml
@@ -2,3 +2,4 @@ dataset: ./datasets/wafer
 output_model: ./models/mymodel_v1.pt
 batch_size: 4
 epochs: 1
+pretrained_model: ./models/pretrained.pt

--- a/modules/model_loader.py
+++ b/modules/model_loader.py
@@ -7,3 +7,9 @@ def load_model(model_path: str) -> Any:
     print(f"모델 로드: {model_path}")
     # 실제 로딩 로직은 생략
     return None
+
+
+def load_pretrained(model_path: str) -> Any:
+    """사전 학습 모델을 로드합니다."""
+    print(f"사전 학습 모델 로드: {model_path}")
+    return load_model(model_path)

--- a/modules/trainer.py
+++ b/modules/trainer.py
@@ -1,5 +1,7 @@
 """모델 학습을 담당하는 모듈."""
 from typing import Any, Dict
+import os
+from modules.model_loader import load_pretrained
 
 
 def train_model(config: Dict[str, Any]) -> None:
@@ -10,6 +12,12 @@ def train_model(config: Dict[str, Any]) -> None:
     """
     dataset_path = config.get("dataset")
     output_model = config.get("output_model")
+    pretrained_model = config.get("pretrained_model")
+
+    if pretrained_model and os.path.exists(pretrained_model):
+        load_pretrained(pretrained_model)
+    elif pretrained_model:
+        print("사전 학습 모델이 존재하지 않습니다: " + pretrained_model)
 
     # 실제 학습 로직은 생략되어 있습니다.
     print(f"데이터셋 로드: {dataset_path}")

--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@ def main() -> None:
     parser.add_argument("--dataset", type=str, help="데이터셋 경로")
     parser.add_argument("--output", type=str, help="모델 저장 경로")
     parser.add_argument("--config", default="config.yaml", help="설정 파일 경로")
+    parser.add_argument("--pretrained", default=None, help="사전 학습 모델 경로")
     args = parser.parse_args()
 
     with open(args.config, "r", encoding="utf-8") as f:
@@ -16,6 +17,8 @@ def main() -> None:
 
     config["dataset"] = args.dataset
     config["output_model"] = args.output
+    if args.pretrained:
+        config["pretrained_model"] = args.pretrained
 
     train_model(config)
 


### PR DESCRIPTION
## Summary
- allow specifying pretrained model in config and CLI
- load pretrained weights before training
- document developer-only training script and pretrained usage

## Testing
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684e252c55cc8321b0c0eab62805e658