### PR TITLE
Improve YOLO training and test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ LiteAOI는 단순한 자동 시각 검사 예제 프로젝트입니다. 본 리�
 ## 환경 준비
 
 - Python 3.10 이상
-- PyTorch
-- OpenCV
-- Albumentations
-- Anomalib
+ - PyTorch
+ - OpenCV
+ - Albumentations
+ - Anomalib
+ - Ultralytics YOLO
 
 필요한 패키지는 `requirements.txt`를 참고하여 설치합니다.
 
@@ -26,6 +27,15 @@ pip install -r requirements.txt
 python train.py --dataset ./datasets/wafer --output ./models/mymodel_v1.pt
 ```
 
+### YOLOv8 학습
+
+YOLOv8을 이용해 객체 탐지 모델을 학습하려면 `yolo_train.py`를 실행합니다. 데이터셋
+구성 파일과 학습 파라미터는 스크립트 안의 상수에서 수정할 수 있습니다.
+
+```bash
+python yolo_train.py
+```
+
 ### 추론
 
 학습된 모델을 사용하여 이미지를 분석하려면 다음 명령을 사용합니다.
@@ -33,6 +43,16 @@ python train.py --dataset ./datasets/wafer --output ./models/mymodel_v1.pt
 ```bash
 python infer.py --input ./test_images --model ./models/mymodel_v1.pt
 ```
+
+### 테스트
+
+YOLOv8 모델을 활용해 간단한 테스트를 진행하려면 `test.py`를 실행합니다. 이미지와 모델의 경로는 스크립트 내의 `TEST_IMAGES_DIR`와 `MODEL_PATH` 변수에서 직접 지정합니다.
+
+```bash
+python test.py
+```
+
+출력된 결과는 콘솔에서 확인할 수 있습니다.
 
 ## 폴더 구조
 

--- a/datasets/dataset.yaml
+++ b/datasets/dataset.yaml
@@ -1,0 +1,4 @@
+train: ./train_images
+val: ./val_images
+nc: 1
+names: ['object']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@
 PyYAML
 opencv-python
 albumentations
+# 최신 YOLO 모델을 사용하기 위해 추가
+ultralytics
 # 실제 프로젝트에서는 PyTorch와 Anomalib 버전에 맞춰 수정

--- a/test.py
+++ b/test.py
@@ -1,0 +1,35 @@
+"""YOLOv8 모델을 로드하여 이미지 예측을 수행하는 스크립트."""
+
+from pathlib import Path
+
+import cv2
+from ultralytics import YOLO
+
+# 테스트용 이미지와 모델 경로를 직접 지정합니다.
+TEST_IMAGES_DIR = "./test_images"
+MODEL_PATH = "./models/best.pt"  # 학습된 모델 경로 또는 프리트레인 모델
+
+
+def main() -> None:
+    """지정된 폴더의 이미지에 대해 YOLOv8 추론을 실행합니다."""
+
+    print(f"YOLOv8 모델 로드: {MODEL_PATH}")
+    model = YOLO(MODEL_PATH)
+
+    image_paths = sorted(Path(TEST_IMAGES_DIR).glob("*.*"))
+    if not image_paths:
+        print("이미지를 찾을 수 없습니다.")
+        return
+
+    for img_path in image_paths:
+        img = cv2.imread(str(img_path))
+        if img is None:
+            continue
+        results = model(img)
+        print(f"{img_path} 결과:")
+        for r in results:
+            print(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/yolo_train.py
+++ b/yolo_train.py
@@ -1,0 +1,26 @@
+"""YOLOv8 모델을 사용자 데이터셋으로 학습하는 스크립트."""
+
+from ultralytics import YOLO
+
+# 데이터셋 설정(YOLO 포맷 YAML)
+DATA_CONFIG = "./datasets/dataset.yaml"
+# 높은 성능을 위해 yolov8x 모델을 사용합니다.
+PRETRAINED_MODEL = "yolov8x.pt"
+EPOCHS = 50
+
+
+def main() -> None:
+    """YOLOv8 훈련을 실행합니다."""
+
+    print(f"프리트레인 모델 로드: {PRETRAINED_MODEL}")
+    model = YOLO(PRETRAINED_MODEL)
+
+    print(f"데이터셋: {DATA_CONFIG}")
+    results = model.train(data=DATA_CONFIG, epochs=EPOCHS, project="runs/train", name="yolo_custom")
+
+    best_path = results.save_dir + "/weights/best.pt"
+    print(f"학습 완료. 최종 모델: {best_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- switch test script to YOLOv8
- add YOLOv8 training script with built‑in dataset config
- document YOLOv8 usage in README
- add dataset example and update requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e256d51b88321a31251732f3c4010