### PR TITLE
Fix dataset path for YOLO training

### DIFF
--- a/yolo_train.py
+++ b/yolo_train.py
@@ -1,9 +1,10 @@
 """YOLOv8 모델을 사용자 데이터셋으로 학습하는 스크립트."""
 
+from pathlib import Path
 from ultralytics import YOLO
 
 # 데이터셋 설정(YOLO 포맷 YAML)
-DATA_CONFIG = "./datasets/dataset.yaml"
+DATA_CONFIG = str((Path(__file__).resolve().parent / "datasets" / "dataset.yaml"))
 # 높은 성능을 위해 yolov8x 모델을 사용합니다.
 PRETRAINED_MODEL = "./models/yolov8x.pt"
 EPOCHS = 50


### PR DESCRIPTION
## Summary
- resolve dataset config path in `yolo_train.py`

## Testing
- `python -m py_compile yolo_train.py`
- `python test.py` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684e2e6722f483218748466a597a9597