### PR TITLE
Fix YOLO dataset paths and save best model

### DIFF
--- a/datasets/dataset.yaml
+++ b/datasets/dataset.yaml
@@ -1,4 +1,4 @@
-train: ./train
-val: ./val
+train: ./train/images
+val: ./val/images
 nc: 1
 names: ['object']

--- a/yolo_train.py
+++ b/yolo_train.py
@@ -1,6 +1,7 @@
 """YOLOv8 모델을 사용자 데이터셋으로 학습하는 스크립트."""
 
 from pathlib import Path
+import shutil
 from ultralytics import YOLO
 
 # 데이터셋 설정(YOLO 포맷 YAML)
@@ -29,6 +30,10 @@ def main() -> None:
 
     best_path = Path(results.save_dir) / "weights" / "best.pt"
     print(f"학습 완료. 최종 모델: {best_path}")
+
+    final_path = OUTPUT_DIR / "best.pt"
+    shutil.copy(best_path, final_path)
+    print(f"베스트 모델을 {final_path}에 저장했습니다.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix dataset.yaml paths to point directly to image folders
- copy the best model into the output directory after training

## Testing
- `python -m py_compile yolo_train.py`

------
https://chatgpt.com/codex/tasks/task_e_684e3503241c8321be4b57904ccbb292