### PR TITLE
Enable CLI parameters for yolo_train

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ python train.py --dataset ./datasets/wafer --output ./models/mymodel_v1.pt \
 ### YOLOv8 학습
 
 YOLOv8을 이용해 객체 탐지 모델을 학습하려면 `yolo_train.py`를 실행합니다. 데이터셋
-구성 파일과 학습 파라미터는 스크립트 안의 상수에서 수정할 수 있습니다.
-`labels.cache` 파일이 존재할 경우 스크립트가 자동으로 삭제하며, 기본 장치는 GPU로
-설정되어 있습니다.
+구성 파일, 사전 학습 모델, 에폭 수와 출력 디렉터리를 인자로 전달해 설정할 수 있습니다.
+`labels.cache` 파일이 존재할 경우 스크립트가 자동으로 삭제하며, 기본 장치는 GPU로 설정되어 있습니다.
 
 ```bash
-python yolo_train.py
+python yolo_train.py --data ./datasets/dataset.yaml \
+                    --model ./models/yolov8x.pt \
+                    --epochs 50 --output ./output
 ```
 
 ### 추론

--- a/yolo_train.py
+++ b/yolo_train.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import shutil
+import argparse
 from ultralytics import YOLO
 
 
@@ -13,29 +14,54 @@ def remove_labels_cache(data_config: str) -> None:
         print(f"캐시 파일 삭제: {cache_path}")
 
 # 데이터셋 설정(YOLO 포맷 YAML)
-DATA_CONFIG = str(Path(__file__).resolve().parent / "datasets" / "dataset.yaml")
+DATA_CONFIG_DEFAULT = str(Path(__file__).resolve().parent / "datasets" / "dataset.yaml")
 # 높은 성능을 위해 yolov8x 모델을 사용합니다.
-PRETRAINED_MODEL = "./models/yolov8x.pt"
-EPOCHS = 50
+PRETRAINED_MODEL_DEFAULT = "./models/yolov8x.pt"
+EPOCHS_DEFAULT = 50
 # 학습된 모델이 저장될 디렉터리
-OUTPUT_DIR = Path(__file__).resolve().parent / "output"
+OUTPUT_DIR_DEFAULT = Path(__file__).resolve().parent / "output"
 
 
 def main() -> None:
     """YOLOv8 훈련을 실행합니다."""
 
-    print(f"프리트레인 모델 로드: {PRETRAINED_MODEL}")
-    if not Path(PRETRAINED_MODEL).exists():
-        raise FileNotFoundError(f"프리트레인 모델을 찾을 수 없습니다: {PRETRAINED_MODEL}")
-    model = YOLO(PRETRAINED_MODEL)
+    parser = argparse.ArgumentParser(description="YOLOv8 학습 스크립트")
+    parser.add_argument(
+        "--data",
+        default=DATA_CONFIG_DEFAULT,
+        help="데이터셋 YAML 경로",
+    )
+    parser.add_argument(
+        "--model",
+        default=PRETRAINED_MODEL_DEFAULT,
+        help="사전 학습 모델 경로",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=EPOCHS_DEFAULT,
+        help="학습 에폭 수",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(OUTPUT_DIR_DEFAULT),
+        help="결과 저장 디렉터리",
+    )
+    args = parser.parse_args()
 
-    print(f"데이터셋: {DATA_CONFIG}")
-    remove_labels_cache(DATA_CONFIG)
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"프리트레인 모델 로드: {args.model}")
+    if not Path(args.model).exists():
+        raise FileNotFoundError(f"프리트레인 모델을 찾을 수 없습니다: {args.model}")
+    model = YOLO(args.model)
+
+    print(f"데이터셋: {args.data}")
+    remove_labels_cache(args.data)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
     results = model.train(
-        data=DATA_CONFIG,
-        epochs=EPOCHS,
-        project=str(OUTPUT_DIR),
+        data=args.data,
+        epochs=args.epochs,
+        project=str(output_dir),
         name="yolo_custom",
         device=0,
     )
@@ -43,7 +69,7 @@ def main() -> None:
     best_path = Path(results.save_dir) / "weights" / "best.pt"
     print(f"학습 완료. 최종 모델: {best_path}")
 
-    final_path = OUTPUT_DIR / "best.pt"
+    final_path = output_dir / "best.pt"
     shutil.copy(best_path, final_path)
     print(f"베스트 모델을 {final_path}에 저장했습니다.")
 


### PR DESCRIPTION
## Summary
- allow providing data, model, epochs and output via arguments in `yolo_train.py`
- document new usage in README

## Testing
- `python -m py_compile yolo_train.py`
- *(help command fails: `ModuleNotFoundError: No module named 'ultralytics'`)*

------
https://chatgpt.com/codex/tasks/task_e_684e43062af0832189870383e10191a2