### PR TITLE
Add DeepPCB dataset auto training

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ python download_dataset.py https://github.com/example/wafer-dataset.git \
     --output ./datasets/wafer
 ```
 
+추가로, [DeepPCB](https://github.com/tangsanli5201/DeepPCB.git) 리포지토리를
+프로젝트와 같은 상위 폴더에 클론해 사용할 수 있습니다.
+
+```bash
+git clone https://github.com/tangsanli5201/DeepPCB.git ../DeepPCB
+```
+
+`test.py` 스크립트는 위 경로가 존재하면 자동으로 DeepPCB의 테스트 이미지를
+사용합니다. 경로가 없을 경우에는 기본 `test_images` 폴더를 참조합니다.
+`train.py`에서도 `--dataset` 옵션을 주지 않으면 해당 위치의 학습 데이터를
+자동으로 사용합니다.
+
 ## 사용 방법
 
 ### 학습
@@ -35,9 +47,11 @@ python download_dataset.py https://github.com/example/wafer-dataset.git \
 불러올 수 있습니다. 다음과 같이 실행합니다.
 
 ```bash
-python train.py --dataset ./datasets/wafer --output ./models/mymodel_v1.pt \
+python train.py --output ./models/mymodel_v1.pt \
     --pretrained ./models/pretrained.pt
 ```
+`--dataset` 인자를 생략하면 `../DeepPCB` 폴더가 존재할 경우 그 안의
+데이터셋을 자동으로 사용합니다. 경로가 없으면 기본 설정값을 따릅니다.
 
 ### YOLOv8 학습
 

--- a/test.py
+++ b/test.py
@@ -5,8 +5,27 @@ from pathlib import Path
 import cv2
 from ultralytics import YOLO
 
-# 테스트용 이미지와 모델 경로를 직접 지정합니다.
-TEST_IMAGES_DIR = "./test_images"
+# 기본 테스트 이미지 폴더.
+# 프로젝트와 같은 상위 경로에 존재하는 DeepPCB 리포지토리를 우선 사용합니다.
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEEPPCB_ROOT = (PROJECT_ROOT / ".." / "DeepPCB").resolve()
+
+_candidate_dirs = [
+    DEEPPCB_ROOT / "dataset" / "test" / "images",
+    DEEPPCB_ROOT / "datasets" / "test" / "images",
+    DEEPPCB_ROOT / "PCBData" / "test" / "images",
+]
+
+TEST_IMAGES_DIR = None
+for _d in _candidate_dirs:
+    if _d.exists():
+        TEST_IMAGES_DIR = str(_d)
+        break
+
+if TEST_IMAGES_DIR is None:
+    # 폴더가 존재하지 않으면 기본 경로를 사용합니다.
+    TEST_IMAGES_DIR = str(PROJECT_ROOT / "test_images")
+
 MODEL_PATH = "./models/best.pt"  # 학습된 모델 경로 또는 프리트레인 모델
 
 

--- a/train.py
+++ b/train.py
@@ -8,7 +8,12 @@ from modules.dataset_downloader import download_dataset
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="LiteAOI 학습 스크립트")
-    parser.add_argument("--dataset", type=str, help="데이터셋 경로")
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="데이터셋 경로 (기본: DeepPCB가 존재하면 해당 경로 사용)",
+    )
     parser.add_argument("--output", type=str, help="모델 저장 경로")
     parser.add_argument("--config", default="config.yaml", help="설정 파일 경로")
     parser.add_argument("--pretrained", default=None, help="사전 학습 모델 경로")
@@ -17,12 +22,32 @@ def main() -> None:
     with open(args.config, "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
-    config["dataset"] = args.dataset
+    # 데이터셋 경로 설정
+    dataset_path = Path(args.dataset) if args.dataset else None
+
+    if dataset_path is None:
+        # 프로젝트 상위 폴더에 클론된 DeepPCB가 있는지 확인합니다.
+        project_root = Path(__file__).resolve().parent
+        deeppcb_root = (project_root / ".." / "DeepPCB").resolve()
+        candidate_roots = [
+            deeppcb_root / "dataset",
+            deeppcb_root / "datasets",
+            deeppcb_root / "PCBData",
+        ]
+        for root in candidate_roots:
+            if (root / "train").exists() or (root / "train" / "images").exists():
+                dataset_path = root
+                print(f"DeepPCB 데이터셋 사용: {dataset_path}")
+                break
+
+    if dataset_path is None:
+        dataset_path = Path(config.get("dataset", "./datasets/wafer"))
+
+    config["dataset"] = str(dataset_path)
     config["output_model"] = args.output
     if args.pretrained:
         config["pretrained_model"] = args.pretrained
 
-    dataset_path = Path(args.dataset)
     if not dataset_path.exists():
         url = config.get("dataset_url")
         if url:


### PR DESCRIPTION
## Summary
- update README with DeepPCB auto-training instructions
- allow `train.py` to locate DeepPCB dataset when `--dataset` is omitted

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684e78d0a62883218365d55c011620b4