### PR TITLE
Fix DeepPCB label loading and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,26 @@ pip install -r requirements.txt
 git clone https://github.com/tangsanli5201/DeepPCB.git ../DeepPCB
 ```
 
-### 2. 데이터셋 준비
+### 2. DeepPCB 데이터셋 구조
+
+DeepPCB는 다음과 같은 디렉터리 구조를 가집니다:
+
+```
+DeepPCB/
+└── PCBData/
+    ├── groupXXXXX/
+    │   ├── XXXXX/         # 테스트 이미지들 (*.jpg)
+    │   └── XXXXX_not/     # 라벨 파일들 (*.txt)
+    └── ...
+```
+
+라벨 파일 형식:
+- 각 줄: `x1 y1 x2 y2 class_id`
+- (x1, y1): 바운딩 박스 좌상단 좌표
+- (x2, y2): 바운딩 박스 우하단 좌표
+- class_id: 1-6 (결함 유형)
+
+### 3. 데이터셋 준비
 
 DeepPCB 데이터셋을 YOLO 형식으로 변환합니다:
 
@@ -37,11 +56,14 @@ python prepare_deeppcb.py --input ../DeepPCB --output ./datasets/deeppcb
 
 이 스크립트는:
 - DeepPCB의 `PCBData` 폴더에서 이미지와 라벨을 읽음
+- DeepPCB 라벨 형식(x1 y1 x2 y2 class_id)을 YOLO 형식(class_id x_center y_center width height)으로 변환
+- 클래스 ID를 1-6에서 0-5로 조정
+- 좌표를 이미지 크기로 정규화
 - 80%/20% 비율로 train/val 세트로 분할
 - YOLO 형식의 디렉터리 구조 생성
 - 학습용 YAML 설정 파일 생성 (`datasets/deeppcb/deeppcb.yaml`)
 
-### 3. YOLOv8 학습
+### 4. YOLOv8 학습
 
 준비된 DeepPCB 데이터셋으로 학습:
 
@@ -62,12 +84,12 @@ python yolo_train.py --dataset ../DeepPCB \
 ## DeepPCB 클래스 정보
 
 DeepPCB는 6가지 PCB 결함 유형을 포함합니다:
-- 0: open (단선)
-- 1: short (단락)
-- 2: mousebite (마우스바이트)
-- 3: spur (스퍼)
-- 4: copper (구리잔여물)
-- 5: pin-hole (핀홀)
+- 0: open (단선) - DeepPCB class 1
+- 1: short (단락) - DeepPCB class 2
+- 2: mousebite (마우스바이트) - DeepPCB class 3
+- 3: spur (스퍼) - DeepPCB class 4
+- 4: copper (구리잔여물) - DeepPCB class 5
+- 5: pin-hole (핀홀) - DeepPCB class 6
 
 ## 추론
 


### PR DESCRIPTION
## 개요
DeepPCB 데이터셋의 실제 라벨 형식을 처리할 수 있도록 로더를 수정하고 문서를 업데이트했습니다.

## 변경사항

### 1. `modules/deeppcb_loader.py` 수정
- **라벨 형식 처리**: DeepPCB의 실제 형식 `x1 y1 x2 y2 class_id` 파싱
- **YOLO 변환**: 중심점 좌표와 크기로 변환, 좌표 정규화
- **클래스 ID 조정**: DeepPCB (1-6) → YOLO (0-5)
- **디렉터리 구조**: `groupXXXXX/XXXXX/` (이미지)와 `groupXXXXX/XXXXX_not/` (라벨) 처리

### 2. `README.md` 업데이트
- DeepPCB 데이터셋 구조 상세 설명 추가
- 라벨 형식 및 변환 과정 문서화
- 클래스 ID 매핑 정보 명시

## 테스트
- DeepPCB 데이터셋 구조에 맞게 이미지와 라벨을 올바르게 로드
- YOLO 형식으로 정확하게 변환
- train/val 분할 정상 동작